### PR TITLE
Introduce the LINKERD_DISABLED env variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linkerd-await"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd-await"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Oliver Gould <ver@buoyant.io>"]
 edition = "2018"
 publish = false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-wrapper that polls linkerd for readiness until it becomes ready and on
 ## Usage
 
 ```
-linkerd-await 0.1.0
+linkerd-await 0.1.1
 Oliver Gould <ver@buoyant.io>
 Wait for linkerd to become ready before running a program.
 
@@ -34,14 +34,29 @@ possible to use this utility in `scratch` images:
 ```dockerfile
 FROM scratch
 # ...
-COPY --from=olix0r/linkerd-await:v0.1.0 /linkerd-await /
+COPY --from=olix0r/linkerd-await:v0.1.1 /linkerd-await /
 ENTRYPOINT ["/linkerd-await", "--"]
 CMD ["/myapp", "-flags"]
 ```
 
+Note that the `LINKERD_DISABLED` flag can be set to bypass `linkerd-await`'s
+readiness checks. This way, `linkerd-await` may be controlled by overriding a
+default environment variable:
+
+```yaml
+    # ...
+    spec:
+      containers:
+        - name: myapp
+          env:
+            - name: LINKERD_DISABLED
+              value: "Linkerd is disabled ;("
+          # ...
+```
+
 ## License
 
-linkerd-await is copyright 2018 the Linkerd authors. All rights reserved.
+linkerd-await is copyright 2019 the Linkerd authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,17 @@ fn main() {
 
     let Opt { uri, backoff, cmd } = Opt::from_args();
 
-    let mut rt = Runtime::new().expect("runtime");
-    if rt.block_on(await_ready(uri, backoff)).is_err() {
-        process::exit(1);
+    let disabled_reason = std::env::var("LINKERD_DISABLED")
+        .ok()
+        .filter(|v| !v.is_empty());
+    match disabled_reason {
+        Some(reason) => eprintln!("Linkerd readiness check skipped: {}", reason),
+        None => {
+            let mut rt = Runtime::new().expect("runtime");
+            if rt.block_on(await_ready(uri, backoff)).is_err() {
+                process::exit(1);
+            }
+        }
     }
 
     let mut args = cmd.into_iter();


### PR DESCRIPTION
When using linkerd-await in a container, it's inconvenient to
enable/disable the await program without rebuilding the container.

By introducing the `LINKERD_DISABLED` environment variable, the
linkerd-await program can be configured transparently and
disabled/enabled at runtime via the environment.