### PR TITLE
ci: Use softprops/action-gh-release@v1 for releases

### DIFF
--- a/.github/actions/release-tag-meta/Dockerfile
+++ b/.github/actions/release-tag-meta/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:1.31
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-tag-meta/action.yml
+++ b/.github/actions/release-tag-meta/action.yml
@@ -1,0 +1,16 @@
+name: release-tag-meta
+description: Extract release metadata from the tag
+inputs:
+  git-ref:
+    required: true
+    description: "The git ref (i.e. starting with refs/tags)"
+outputs:
+  tag:
+    description: "The git tag (without the refs prefix)"
+  name:
+    description: "The release name"
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.git-ref }}

--- a/.github/actions/release-tag-meta/entrypoint.sh
+++ b/.github/actions/release-tag-meta/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+ref="$1"
+tag=$(echo "$ref" | sed s,^refs/tags/,,)
+name=$(echo "$tag" | sed s,^release/,,)
+
+echo ::set-output "name=tag::$tag"
+echo ::set-output "name=name::$name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Get tag
-      run: |
-        echo "${{ github.ref }}" | sed -E 's,^refs/tags/,,' >release.tag
-        cat release.tag
-        echo "${{ github.ref }}" | sed -E 's,^refs/tags/release/,,' >release.name
-        cat release.name
+    - name: Get Tag Info
+      id: release-tag-meta
+      uses: ./.github/actions/release-tag-meta
+      with:
+        git-ref: ${{ github.ref }}
 
     - name: Build
       uses: docker://rust:1.37-buster
@@ -26,12 +25,11 @@ jobs:
         entrypoint: make
         args: release
 
-    - name: Upload
-      uses: docker://github/ghx:master
+    - name: Release
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        entrypoint: sh
-        # bastard blackbox ghx reads GITHUB_REF and then barfs on it, no matter
-        # its command-line args. so just hide that env from it..
-        args: -c "unset GITHUB_REF ; cd release && ghx release create --verbose --tag=$(cat ../release.tag) --name=$(cat ../release.name) --ref ${{ github.sha }} --draft *"
+        files: release/*
+        name: ${{steps.release-tag-meta.name}}
+


### PR DESCRIPTION
github/ghx is not supported, and softprops' work seems good! I had to
introduce a local helper action to create properly formatted release
names.
 