### PR TITLE
Add a --shutdown mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "linkerd-await"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "http",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -283,6 +295,7 @@ version = "0.1.3"
 dependencies = [
  "http",
  "hyper",
+ "nix",
  "regex",
  "structopt",
  "tokio",
@@ -294,7 +307,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -309,17 +322,40 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.6",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
 ]
 
 [[package]]
@@ -335,14 +371,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -440,12 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
 name = "regex"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,13 +532,12 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -551,11 +611,16 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
+ "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
+ "mio-uds",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -595,7 +660,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "pin-project-lite",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,36 +93,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.7"
+name = "futures"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
-name = "futures-task"
-version = "0.3.7"
+name = "futures-executor"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
-
-[[package]]
-name = "futures-util"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -221,6 +283,7 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 name = "linkerd-await"
 version = "0.2.0"
 dependencies = [
+ "futures",
  "http",
  "hyper",
  "nix",
@@ -357,6 +420,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +475,12 @@ checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 http = "0.2"
 hyper = "0.13.8"
+nix = "0.19"
 regex = "1"
 structopt = "0.3"
-tokio = { version = "0.2", features = ["macros", "time"] }
+tokio = { version = "0.2", features = ["macros", "process", "signal", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkerd-await"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 nix = "0.19"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ USAGE:
     linkerd-await [OPTIONS] [CMD]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help        Prints help information
+    -S, --shutdown    Forks the program and triggers proxy shutdown on completion
+    -V, --version     Prints version information
 
 OPTIONS:
     -b, --backoff <backoff>    Time to wait after a failed readiness check [default: 1s]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ARGS:
 ```dockerfile
 # Create a base layer with linkerd-await froma recent release.
 FROM docker.io/curlimages/curl:latest as linkerd
-ARG LINKERD_AWAIT_VERSION=v0.1.3
+ARG LINKERD_AWAIT_VERSION=v0.2.0
 RUN curl -sSLo /tmp/linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await
 RUN chmod 755 /tmp/linkerd-await
 
@@ -45,7 +45,10 @@ RUN make build
 FROM scratch
 COPY --from=linkerd /tmp/linkerd-await /linkerd-await
 COPY --from=app /app/myapp /myapp
-ENTRYPOINT ["/linkerd-await", "--"]
+# In this case, we configure the proxy to be shutdown after `myapp` completes
+# running. This is only really needed for jobs where the application is
+# expected to complete on its own (namely, `Jobs` and `Cronjobs`)
+ENTRYPOINT ["/linkerd-await", "--shutdown" "--"]
 CMD  ["/myapp"]
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Opt {
     #[structopt(
         short = "S",
         long = "shutdown",
-        help = "Causes the program to be forked so that proxy shutdown can be triggered once it completes"
+        help = "Forks the program and triggers proxy shutdown on completion"
     )]
     shutdown: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
         cmd,
     } = Opt::from_args();
 
-    let authority = http::uri::Authority::from_str(&format!("127.0.0.1:{}", port)).unwrap();
+    let authority = http::uri::Authority::from_str(&format!("localhost:{}", port)).unwrap();
 
     if cmd.is_empty() {
         std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use std::time::Duration;
-use std::{error, fmt};
+use regex::Regex;
+use std::{convert::TryInto, error, fmt};
 use structopt::StructOpt;
-use tokio::time::delay_for;
+use tokio::time::{delay_for, Duration};
 
 #[derive(Clone, Debug, StructOpt)]
 #[structopt()]
@@ -11,10 +11,10 @@ use tokio::time::delay_for;
 struct Opt {
     #[structopt(
         short = "u",
-        long = "uri",
-        default_value = "http://127.0.0.1:4191/ready"
+        long = "base-url",
+        default_value = "http://127.0.0.1:4191/"
     )]
-    uri: http::Uri,
+    base_url: http::Uri,
 
     #[structopt(
         short = "b",
@@ -24,16 +24,25 @@ struct Opt {
     )]
     backoff: Duration,
 
+    #[structopt(
+        short = "S",
+        long = "shutdown",
+        help = "Causes the program to be forked so that proxy shutdown can be triggered once it completes"
+    )]
+    shutdown: bool,
+
     #[structopt(name = "CMD")]
     cmd: Vec<String>,
 }
 
 #[tokio::main]
 async fn main() {
-    use std::os::unix::process::CommandExt;
-    use std::process::{self, Command};
-
-    let Opt { uri, backoff, cmd } = Opt::from_args();
+    let Opt {
+        base_url,
+        backoff,
+        shutdown,
+        cmd,
+    } = Opt::from_args();
 
     let disabled_reason = std::env::var("LINKERD_DISABLED")
         .ok()
@@ -41,22 +50,97 @@ async fn main() {
     match disabled_reason {
         Some(reason) => eprintln!("Linkerd readiness check skipped: {}", reason),
         None => {
-            await_ready(uri, backoff).await;
+            await_ready(base_url.clone(), backoff).await;
         }
     }
 
     let mut args = cmd.into_iter();
     if let Some(command) = args.next() {
-        let mut cmd = Command::new(&command);
-        cmd.args(args);
-
-        let err = cmd.exec();
-        eprintln!("Failed to exec child program: {}: {}", command, err);
-        process::exit(1);
+        if shutdown {
+            let res = fork_and_wait(command, args).await;
+            send_shutdown(base_url).await;
+            if let Ok(status) = res {
+                if let Some(code) = status.code() {
+                    std::process::exit(code);
+                }
+            }
+            std::process::exit(EX_OSERR);
+        } else {
+            exec(command, args);
+        }
     }
 }
 
-async fn await_ready(uri: http::Uri, backoff: Duration) {
+const EX_OSERR: i32 = 71;
+
+fn exec(name: String, args: impl IntoIterator<Item = String>) {
+    use std::{
+        os::unix::process::CommandExt,
+        process::{self, Command},
+    };
+
+    let mut cmd = Command::new(&name);
+    cmd.args(args);
+
+    let err = cmd.exec();
+    eprintln!("Failed to exec child program: {}: {}", name, err);
+    process::exit(EX_OSERR);
+}
+
+#[allow(warnings)]
+async fn fork_and_wait(
+    name: String,
+    args: impl IntoIterator<Item = String>,
+) -> std::io::Result<std::process::ExitStatus> {
+    use tokio::{
+        process::Command,
+        signal::unix::{signal, SignalKind},
+    };
+
+    let mut cmd = Command::new(&name);
+    cmd.args(args);
+
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!("Failed to fork child program: {}: {}", name, e);
+            std::process::exit(EX_OSERR);
+        }
+    };
+
+    // Proxy relevant signals.
+    let cid = nix::unistd::Pid::from_raw(child.id().try_into().expect("Invalid PID"));
+    tokio::spawn(async move {
+        // SIGINT  - To allow Ctrl-c to emulate SIGTERM while developing.
+        let mut sigint =
+            signal(SignalKind::interrupt()).expect("Failed to register signal handler");
+        // SIGTERM - Kubernetes sends this to start a graceful shutdown.
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("Failed to register signal handler");
+        tokio::select! {
+            _ = sigint.recv() => {
+                if let Err(e) = nix::sys::signal::kill(cid, nix::sys::signal::Signal::SIGINT) {
+                    eprintln!("Failed to forward SIGINT to child process: {}", e);
+                }
+            }
+            _ = sigterm.recv() => {
+                if let Err(e) = nix::sys::signal::kill(cid, nix::sys::signal::Signal::SIGTERM) {
+                    eprintln!("Failed to forward SIGTERM to child process: {}", e);
+                }
+            }
+        };
+    });
+
+    child.await
+}
+
+async fn await_ready(base_url: http::Uri, backoff: Duration) {
+    let uri = {
+        let mut parts = base_url.into_parts();
+        parts.path_and_query = Some("/ready".try_into().unwrap());
+        http::Uri::from_parts(parts).expect("Ready URI must be valid")
+    };
+
     let client = hyper::Client::default();
     loop {
         match client.get(uri.clone()).await {
@@ -66,9 +150,23 @@ async fn await_ready(uri: http::Uri, backoff: Duration) {
     }
 }
 
-fn parse_duration(s: &str) -> Result<Duration, InvalidDuration> {
-    use regex::Regex;
+async fn send_shutdown(base_url: http::Uri) {
+    let uri = {
+        let mut parts = base_url.into_parts();
+        parts.path_and_query = Some("/shutdown".try_into().unwrap());
+        http::Uri::from_parts(parts).expect("Shutdown URI must be valid")
+    };
 
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri(uri)
+        .body(Default::default())
+        .expect("shutdown request must be valid");
+
+    let _ = hyper::Client::default().request(req).await;
+}
+
+fn parse_duration(s: &str) -> Result<Duration, InvalidDuration> {
     let re = Regex::new(r"^\s*(\d+)(ms|s|m|h|d)?\s*$").expect("duration regex");
     let cap = re.captures(s).ok_or(InvalidDuration)?;
     let magnitude = cap[1].parse().map_err(|_| InvalidDuration)?;


### PR DESCRIPTION
When the --shutdown flag is provided, the specified command is forked
(instead of simply exec'd) and the linkerd-await program forwards
SIGTERM to the child process. When the child process completes, the
proxy is shutdown via its admin interface.

Depends on https://github.com/linkerd/linkerd2-proxy/pull/811