### PR TITLE
Replace the --uri flag with a --port flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,8 +213,9 @@ checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "linkerd-await"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
+ "http",
  "hyper",
  "regex",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "linkerd-await"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 
 [dependencies]
+http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 regex = "1"
 structopt = "0.3"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ A command-wrapper that polls Linkerd for readiness until it becomes ready and on
 ## Usage
 
 ```
-linkerd-await 0.1.3
-Oliver Gould <ver@buoyant.io>
-Wait for linkerd to become ready before running a program.
+linkerd-await 0.2.0
+Wait for linkerd to become ready before running a program
 
 USAGE:
     linkerd-await [OPTIONS] [CMD]...
@@ -17,8 +16,8 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -b, --backoff <backoff>     [default: 1s]
-    -u, --uri <uri>             [default: http://127.0.0.1:4191/ready]
+    -b, --backoff <backoff>    Time to wait after a failed readiness check [default: 1s]
+    -p, --port <port>          The port of the local Linkerd proxy admin server [default: 4191]
 
 ARGS:
     <CMD>...
@@ -45,27 +44,19 @@ In a multi-stage build, `linkerd-await` can be downloaded in a previous stage as
 
 ```dockerfile
 FROM node:alpine as builder
-
 WORKDIR /app
-
 RUN apk add --update curl && rm -rf /var/cache/apk/*
-
 COPY package*.json ./
 RUN npm install --production
 COPY . .
-
-ARG LINKERD_AWAIT_VERSION=v0.1.3
+ARG LINKERD_AWAIT_VERSION=v0.2.0
 RUN curl -vsLO https://github.com/olix0r/linkerd-await/releases/download/release/${LINKERD_AWAIT_VERSION}/linkerd-await && \
   chmod +x linkerd-await
 
 FROM node:alpine
-
 WORKDIR /app
-
 COPY --from=builder /app .
-
 USER 10001
-
 ENTRYPOINT ["./linkerd-await", "--"]
 CMD  ["node", "index.js"]
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use std::{error, fmt};
+use std::{error, fmt, str::FromStr};
 use structopt::StructOpt;
 use tokio::time;
 
@@ -9,11 +9,12 @@ use tokio::time;
 /// Wait for linkerd to become ready before running a program.
 struct Opt {
     #[structopt(
-        short = "u",
-        long = "uri",
-        default_value = "http://127.0.0.1:4191/ready"
+        short = "p",
+        long = "port",
+        default_value = "4191",
+        help = "The port of the local Linkerd proxy admin server"
     )]
-    uri: hyper::Uri,
+    port: u16,
 
     #[structopt(
         short = "b",
@@ -32,7 +33,9 @@ async fn main() {
     use std::os::unix::process::CommandExt;
     use std::process::{self, Command};
 
-    let Opt { uri, backoff, cmd } = Opt::from_args();
+    let Opt { port, backoff, cmd } = Opt::from_args();
+
+    let authority = http::uri::Authority::from_str(&format!("127.0.0.1:{}", port)).unwrap();
 
     let disabled_reason = std::env::var("LINKERD_DISABLED")
         .ok()
@@ -40,7 +43,7 @@ async fn main() {
     match disabled_reason {
         Some(reason) => eprintln!("Linkerd readiness check skipped: {}", reason),
         None => {
-            await_ready(uri, backoff).await;
+            await_ready(authority, backoff).await;
         }
     }
 
@@ -55,7 +58,13 @@ async fn main() {
     }
 }
 
-async fn await_ready(uri: hyper::Uri, backoff: time::Duration) {
+async fn await_ready(auth: http::uri::Authority, backoff: time::Duration) {
+    let uri = http::Uri::builder()
+        .authority(auth)
+        .path_and_query("/ready")
+        .build()
+        .unwrap();
+
     let client = hyper::Client::default();
     loop {
         match client.get(uri.clone()).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
 
 async fn await_ready(auth: http::uri::Authority, backoff: time::Duration) {
     let uri = http::Uri::builder()
-        .scheme("http")
+        .scheme(http::uri::Scheme::HTTP)
         .authority(auth)
         .path_and_query("/ready")
         .build()


### PR DESCRIPTION
This change replaces the --uri flag with a --port flag. The application
then hardcodes both the localhost address as well as the /ready admin
API endpoint.

Practically, this application is tightly coupled to Linkerd's admin
interface and doesn't need to be highly configurable.