### PR TITLE
Support the LINKERD_AWAIT_DISABLED env

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ CMD  ["/myapp"]
 
 ### Disabling `linkerd-await` at runtime
 
-Note that the `LINKERD_DISABLED` flag can be set to bypass `linkerd-await`'s
-readiness checks. This way, `linkerd-await` may be controlled by overriding a
-default environment variable:
+The `LINKERD_AWAIT_DISABLED` (or `LINKERD_DISABLED`) environment variable can
+be set to bypass `linkerd-await`'s readiness checks. This way,
+`linkerd-await` may be controlled by overriding a default environment
+variable:
 
 ```yaml
     # ...
@@ -64,7 +65,7 @@ default environment variable:
       containers:
         - name: myapp
           env:
-            - name: LINKERD_DISABLED
+            - name: LINKERD_AWAIT_DISABLED
               value: "Linkerd is disabled ;("
           # ...
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,9 +91,14 @@ async fn main() {
 }
 
 fn linkerd_disabled_reason() -> Option<String> {
-    std::env::var("LINKERD_DISABLED")
+    std::env::var("LINKERD_AWAIT_DISABLED")
         .ok()
         .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("LINKERD_DISABLED")
+                .ok()
+                .filter(|v| !v.is_empty())
+        })
 }
 
 /// Execs the process.


### PR DESCRIPTION
The `LINKERD_DISABLED` environment variable can be used to disable
`linkerd-await`; but this can be misleading, as sometimes all you really
want to do is disable `linkerd-await` but not actually disable the
Linkerd proxy.

This change updates `linkerd-await` to prefer a new environment
variable, `LINKERD_AWAIT_DISABLED`, in addition to `LINKERD_DISABLED`.